### PR TITLE
fix(confg/fetch_ips): wrong path, missing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk add --update bash py-pip python3-dev postgresql-dev gcc musl-dev supervisor curl openssl ca-certificates wget
+RUN apk add --update grep bash py-pip python3-dev postgresql-dev gcc musl-dev supervisor curl openssl ca-certificates wget
 RUN update-ca-certificates
 RUN mkdir -p /srv/ip-reputation
 WORKDIR /srv/ip-reputation

--- a/deploy/crontab
+++ b/deploy/crontab
@@ -1,5 +1,5 @@
 # m   h   dom  mon  dow  command
-*     4   *    *    *    cd /srv/ip-reputation/        && ./reputation-rbl.sh  >> /var/log/reputation-rbl.log 2>&1
-*/30  *   *    *    *    cd /srv/ip-reputation/        && ./spamhaus-bl.sh     >> /var/log/spamhaus-bl.log    2>&1
-*     6   *    *    *    cd /srv/ip-reputation/config/ && ./fetch_ips.sh       >> /var/log/fetch_ips.log      2>&1
+*     4   *    *    *    cd /srv/ip-reputation/                   && ./reputation-rbl.sh  >> /var/log/reputation-rbl.log 2>&1
+*/30  *   *    *    *    cd /srv/ip-reputation/                   && ./spamhaus-bl.sh     >> /var/log/spamhaus-bl.log    2>&1
+*     6   *    *    *    cd /srv/ip-reputation/reputation/config/ && ./fetch_ips.sh       >> /var/log/fetch_ips.log      2>&1
 

--- a/reputation/config/fetch_ips.sh
+++ b/reputation/config/fetch_ips.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
+CURRENT_DIR=`dirname \`readlink -f $0\``
+REPUTATION_DIR="${CURRENT_DIR}/.."
+AS_NUMBER=$(${REPUTATION_DIR}/get_secret.py AS_NUMBER)
+
 if [ -z "${AS_NUMBER}" ]
 then
     >&2 echo "No AS_NUMBER varenv defined. Please define it to be able to build your IPs list."
     exit 1
 fi
-
-CURRENT_DIR=`dirname \`readlink -f $0\``
 
 pyasn_util_download.py --latest
 pyasn_util_convert.py --single rib.*.bz2 ipasn.dat

--- a/reputation/config/fetch_ips.sh
+++ b/reputation/config/fetch_ips.sh
@@ -10,7 +10,9 @@ then
     exit 1
 fi
 
-pyasn_util_download.py --latest
+directory=$(date -u +"%Y.%m")
+to_download=$(curl http://archive.routeviews.org/bgpdata/${directory}/RIBS/ | tail -n4 | head -n1 | grep -Po '</td><td><a href="\K(.*)(?=">rib)')
+wget http://archive.routeviews.org/bgpdata/${directory}/RIBS/${to_download}
 pyasn_util_convert.py --single rib.*.bz2 ipasn.dat
 
 # the content of ipasn.dat will be something like:


### PR DESCRIPTION
This PR fixes the broken `fetch_ips.sh` script, used to fetch the IPs owned by a given AS.